### PR TITLE
Fix: Correctly configure `tailwind.config.ts` to retain default settings

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,8 +8,10 @@ const config: Config = {
     "./src/slices/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-    backgroundImage: {
-      'cubes-pattern': "url('/images/cubes.png')",
+    extend: {
+      backgroundImage: {
+        'cubes-pattern': "url('/images/cubes.png')",
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
- Added `extend` property to retain default settings while adding custom background images.
- Resolved issue where custom background images were overriding default text clipping settings.